### PR TITLE
License recommendation added

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,7 @@
+Copyright 2023 YG-Drone-Project
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -71,3 +71,9 @@ This part is responsible for running the automated test cases on the repo
 3. Linting
 
 This part is to analyze the code in terms of code standards
+
+
+## License
+
+This project is licensed under the terms of the [MIT License](LICENSE.txt).
+

--- a/backend/drone.py
+++ b/backend/drone.py
@@ -1,3 +1,5 @@
+# Copyright 2023 YG-Drone-Project
+
 from dronekit import connect, VehicleMode
 import time
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -1,3 +1,5 @@
+# Copyright 2023 YG-Drone-Project
+
 from flask import Flask, request, jsonify
 from flask_cors import CORS
 from drone import DroneController

--- a/kivi_app/main.py
+++ b/kivi_app/main.py
@@ -1,3 +1,5 @@
+# Copyright 2023 YG-Drone-Project
+
 # Import modules 
 from kivy.app import App
 from kivy.uix.button import Button


### PR DESCRIPTION
Here is my justification for selecting the MIT license: 

We are free to use, modify, distribute, and sublicense the software under the terms of the MIT License, which is a permissive license. The open-source community recognizes and accepts it broadly. The following justifies why the MIT License would be appropriate for our application:

Flexibility: The MIT License gives us the flexibility to use the software for any purpose, including commercial use. This allows us to build a mobile application for IOS and Android.

Compatibility: The MIT License is compatible with many other open-source licenses. If we need to plan to incorporate other open-source libraries or components into our application later, this license allows us to do so without conflicting license requirements.

Community-friendly: The MIT License encourages collaboration and contribution from the community. By using this license, we can make our project more attractive to potential contributors who are familiar with and prefer permissive licenses.